### PR TITLE
process docu: release team CI Signal Lead updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ be familiar with the release process and remain ready to discharge the responsib
   finding manual testing volunteers, and ensuring any issues discovered are communicated widely and fixed quickly
 
 ### CI Signal Lead
-- Monitors various e2e tests in sig-release dashboard ([master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking), [master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade), [x.y-blocking](https://k8s-testgrid.appspot.com/sig-release-1.11-blocking))on a regular basis and provides early and continuous signals on release and test health to both the Release team and SIGs
+- Monitors various e2e tests in sig-release dashboard ([master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking), [master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade), [x.y-blocking](https://k8s-testgrid.appspot.com/sig-release-1.11-blocking)) on a regular basis and provides early and continuous signals on release and test health to both Release team and owning SIGs
 - Ensures that all release blocking tests provide a clear Go/No-Go signal for the release
 - Tracks and finds owners to fix any failing or flaky tests in the release blocking dashboards mentioned above
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ be familiar with the release process and remain ready to discharge the responsib
   finding manual testing volunteers, and ensuring any issues discovered are communicated widely and fixed quickly
 
 ### CI Signal Lead
-- Monitors various e2e tests ([master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking), [master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade), [x.y-blocking](https://k8s-testgrid.appspot.com/sig-release-1.11-blocking))on a regular basis and provides early and continuous signals on release and test health to both the Release team and SIGs
+- Monitors various e2e tests in sig-release dashboard ([master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking), [master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade), [x.y-blocking](https://k8s-testgrid.appspot.com/sig-release-1.11-blocking))on a regular basis and provides early and continuous signals on release and test health to both the Release team and SIGs
 - Ensures that all release blocking tests provide a clear Go/No-Go signal for the release
 - Tracks and finds owners to fix any failing or flaky tests in the release blocking dashboards mentioned above.
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ be familiar with the release process and remain ready to discharge the responsib
 ### CI Signal Lead
 - Monitors various e2e tests in sig-release dashboard ([master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking), [master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade), [x.y-blocking](https://k8s-testgrid.appspot.com/sig-release-1.11-blocking))on a regular basis and provides early and continuous signals on release and test health to both the Release team and SIGs
 - Ensures that all release blocking tests provide a clear Go/No-Go signal for the release
-- Tracks and finds owners to fix any failing or flaky tests in the release blocking dashboards mentioned above.
+- Tracks and finds owners to fix any failing or flaky tests in the release blocking dashboards mentioned above
 
 ### Release Team Shadow
 Any Release Team member may select one or more mentees to shadow the release process in order to help fulfill future

--- a/README.md
+++ b/README.md
@@ -200,8 +200,9 @@ be familiar with the release process and remain ready to discharge the responsib
   finding manual testing volunteers, and ensuring any issues discovered are communicated widely and fixed quickly
 
 ### CI Signal Lead
-- Ensures that all non-upgrade test CI provides a clear go/no-go signal for the release
-- Tracks and finds owners to fix any issues with any (non-upgrade) tests
+- Monitors various e2e tests ([master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking), [master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade), [x.y-blocking](https://k8s-testgrid.appspot.com/sig-release-1.11-blocking))on a regular basis and provides early and continuous signals on release and test health to both the Release team and SIGs
+- Ensures that all release blocking tests provide a clear Go/No-Go signal for the release
+- Tracks and finds owners to fix any failing or flaky tests in the release blocking dashboards mentioned above.
 
 ### Release Team Shadow
 Any Release Team member may select one or more mentees to shadow the release process in order to help fulfill future

--- a/release-process-documentation/release-team-guides/ci-signal-playbook.md
+++ b/release-process-documentation/release-team-guides/ci-signal-playbook.md
@@ -1,6 +1,7 @@
 # CI Signal Lead Playbook
 
 ## Overview of CI Signal responsibilities
+
 CI Signal lead assumes the responsibility of the quality gate for the release. This person is responsible for:
 - Monitors various e2e tests in sig-release dashboard ([master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking), [master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade), [x.y-blocking](https://k8s-testgrid.appspot.com/sig-release-1.11-blocking))on a regular basis and provides early and continuous signals on release and test health to both the Release team and SIGs
 - Ensures that all release blocking tests provide a clear Go/No-Go signal for the release
@@ -10,55 +11,119 @@ CI Signal lead assumes the responsibility of the quality gate for the release. T
   - Understand and fix the test for the current release
   - Understand if the test needs to be release blocking
   - Advise Release team in making informed go/no-go calls 
-  - Work with sig-testing on any possible test infra improvement to help improve test pass rate
-- Makes recommendations to Sig-Release for promoting and demoting Release blocking and Merge blocking tests as per the [Blocking tests Proposal](https://docs.google.com/document/d/1kCDdmlpTnHPQt5z8JzODdFCc3T2D4MKR53twsDZu20c/edit)
+  - Work with SIG-Testing on any possible test infra improvement to help improve test pass rate
+- Makes recommendations to SIG-Release for promoting and demoting Release blocking and Merge blocking tests as per the [Blocking tests Proposal](https://docs.google.com/document/d/1kCDdmlpTnHPQt5z8JzODdFCc3T2D4MKR53twsDZu20c/edit)
 
 ### Explicit detail is important:
+
 - If you're looking for answer that's not in this document, don't just ask me, please file an issue so we can keep the document current.
 - If I don't file an issue for a failing job or test, _I will lose track of it_, so I err on the side of filing an issue even if someone told me something in some other medium
 - If a dashboard isn't listed here, or a test isn't on one of the listed dashboards, **_I'm not looking at it_**
 
 ## Requirements
+
 - I need the ability to notify kubernetes org github teams, so I must be a kubernetes org collaborator or member
   - The process to become one of these is in [our community membership ladder](https://github.com/kubernetes/community/blob/master/community-membership.md#requirements-for-outside-collaborators)
 - I need the ability to add a milestone to issues, so I must be a member of the [kubernetes-pm github team](https://github.com/orgs/kubernetes/teams/kubernetes-pm/members)
   - The process to join this group is in [our community project-managers page](https://github.com/kubernetes/community/blob/master/project-managers/README.md#joining-the-group)
 - I need to understand what tests matter and generally how our testing infra is wired together
   - I can ask previous CI Signal leads for advice
-  - I can ask sig-testing for guidance
+  - I can ask SIG-Testing for guidance
 
 ## Overview of tasks across release timeline
 
 For any release, its schedule and activities/deliverable for each week will be published in the release directory, e.g: [1.11 schedule](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.11/release-1.11.md#timeline). This section talks about specific CI Signal lead deliverable for each milestone in the release cycle.
 
 ### Pre Feature Freeze
-Here are some good early deliverables from the CI Signal lead between start of release and feature freeze
-- Maintain a master tracking sheet and keep it up-to-date with  issues tracking any test issue (failure/flake) - [Sample sheet](https://docs.google.com/spreadsheets/d/1j2K8cxraSp8jZR2S-kJUT6GNjtXYU9hocNRiVUGZWvc/edit#gid=127492362)
+
+Here are some good early deliverables from the CI Signal lead between start of release and feature freeze.
+- Maintain a master tracking sheet and keep it up-to-date with issues tracking any test failure/flake - [Sample sheet](https://docs.google.com/spreadsheets/d/1j2K8cxraSp8jZR2S-kJUT6GNjtXYU9hocNRiVUGZWvc/edit#gid=127492362)
 - Copy over any open test issues from previous release (ask previous CI Signal lead for the tracker sheet) and follow up on them with owners
-- Monitor [master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking) and [master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade) dashboards **twice a week** and ensure all failures and flakes have issues open
+- Monitor [master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking) and [master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade) dashboards **twice a week** and ensure all failures and flakes are tracked via open issues
   - Make sure all open issues have a kind/bug, priority/flake or priority/failing-test, priority/important-soon labels 
-  - Make sure the issue is assigned against the current milestone 1.xx, using /milestone
+  - Make sure the issue is assigned against the current milestone 1.x, using /milestone
   - Assign the issue to appropriate SIG using /sig label
-  - Add @kubernetes/sig-foo-test-failures to get SIG’s attention on the issue
   - CC the release manager and bug triage lead
-  - Draw SIG's attention to the test failure by post in SIG’s Slack channel. This can also help routing the issue to the rightful owner(s) in the SIG
+  - Add @kubernetes/sig-foo-test-failures to draw SIG’s attention to the issue
+  - Post the test failure in SIG’s Slack channel to get help in routing the issue to the rightful owner(s)
   - [Sample test failure issue](https://github.com/kubernetes/kubernetes/issues/63611)
 - Build and maintain a document of area experts / owners across SIGs for future needs eg: Scalability experts, upgrade test experts etc
   
 #### **_Best Practice:_** 
 The SLA and involvement of signal lead at this stage might vary from release to release (and the CI Signal lead). However in an effort to establish a baseline of the test health, the signal lead can take an initial stab at the tests runs at the start of the release, open issues, gather and report on the current status. Post that, it might suffice to check on the tests **twice a week** due to high code churn and expected test instability.
 
-### Feature Freeze to Code Freeze
-Day to day tasks remain pretty much the same as before, with the following slight changes
-- Post 1.xx.0-beta.0 release, [master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking) and [master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade) dashboards **every other day**.
-- Starting now, curate and send a **Weekly CI Signal report** escalating current test failures and flakes to the entire kubernetes-dev community. Such conitnuous and early reporting of test health went a long way in rallying SIG attention to test failures and stabilizing the release much early in the release cycle.
-  - 
+### Feature Freeze to Code Slush
 
-### Tips and Tricks when checking test dashboards
+Day to day tasks remain pretty much remain the same as before, with the following slight changes
+- Monitor [master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking) dashboard **daily**
+- Monitor [master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade) **every other day**
+- Starting now, curate a **weekly CI Signal report** escalating current test failures and flakes and send to kubernetes-dev@googlegroups.com community. [See below](#reporting-status) for more details
+
+### Code Slush to Code Freeze
+
+This is when things really begin to ramp up in the release cycle with active bug triaging and followup on possible release blocking issues to assess release health. Day to day tasks of CI Signal lead include
+- Audit test status of master-blocking, master-upgrade and release-1.x.y-blocking dashboards on **daily basis**
+- Keep issues' status upto-date on GitHub
+- Work closely with SIGs, test owners, Bug Triage lead and Release team in triaging, punting and closing issues
+- Update issue tracker frequently so anyone on the release team can get latest status and help followup on open issues
+- Continue sending [weekly CI signal report](#reporting-status)
+
+### During Code Freeze
+
+- Continue best practices from Code slush stage. Monitor master-blocking, master-upgrade and release-1.x.y-blocking dashboards on **daily basis**
+- Quickly escalate any new failures to release team and SIGs
+
+### Exit Code Freeze
+
+- Once 1.x.y-rc.1 release branch is cut and master re-opens for next release PRs, stop monitoring master-blocking and **focus only on master-upgrade and 1.x.y-blocking dashboards on daily basis**
+
+## Special high risk test categories to monitor
+
+Historically there a couple of families of test that are hard to stabilize, regression prone and pose a high risk of delaying and/or derailing a release. As CI Sigbal lead it is highly recommended to pay close attention and extra caution when dealing with test failures in the following areas.
+
+### Scalability tests
+Scalability testing is inherently challenging and regressions in this area are potentially a huge project risk 
+- Requires lots and lots of servers running tests, and hence expensive
+- Tests are long running, so especially hard/expensive/slow to resolve issues via Git bisection
+- Examination of results is actually the bigger more expensive part of the situation.  
+
+The following scalability jobs/tests could regress quite easily (due to seemingly unrelated PRs anywhere in k8s codebase), require constant manual monitoring/triaging and domain expertise to investigate and resolve.
+- [master-blocking gci-gce-100](https://k8s-testgrid.appspot.com/sig-release-master-blocking#gci-gce-100)
+- [master-blocking gce-scale-correctness](https://k8s-testgrid.appspot.com/sig-release-master-blocking#gce-scale-correctness)
+- [master-blocking gce-scale-performance](https://k8s-testgrid.appspot.com/sig-release-master-blocking#gce-scale-performance)
+- [release 1.xx-blocking gce-scalability-1.xx](https://k8s-testgrid.appspot.com/sig-release-1.10-blocking#gce-scalability-1.10) (Post release branch cut)
+
+The CI Signal lead should 
+- Continuously monitor these tests early in the release cycle, ensure issues are filed and escalated to the Release team and right owners in SIG-Scalability (@bobwise, @shyamjvs, @wojtek-t) 
+- Work with SIG-Scalability to understand if the failure is a product regression versus a test issue (flake) and in either cases followup closely on a fix
+- Additionally it might help to monitor SIG-Scalability’s performance dashboard to flag if and when there is considerable performance degradation
+
+Starting in 1.11, scalability tests are now blocking OSS presubmit. Specifically we are running performance tests on gce-100 and kubemark-500 setups. This is a step towards catching regressions sooner and stabilizing the release faster.
+
+### Upgrade/Downgrade tests
+[Upgrade tests](https://k8s-testgrid.appspot.com/sig-release-master-upgrade#Summary) are inherently tricky in the way they are setup to run and test. We run multiple  combinations that test upgrading an downgrading 
+- just the master
+- entire cluster
+- on gce and gke
+- in parallel and otherwise
+
+We also run **skewed tests** which involve running the old k8s version’s tests i.e., 1.x-1.y tests, against the new (upcoming) version i.e., 1.x.y. Many of those tests will (and did) fail because of intentional changes in the new version, putting us in the position of back-patching tests to old versions and thus forcing us to add lots of new code to a stable release. 
+
+The CI Signal lead should 
+- Continuously monitor the [master-upgrade tests](https://k8s-testgrid.appspot.com/sig-release-master-upgrade#Summary) throughout the cycle
+- If an upgrade/downgrade job is listed as FAILING, check the following and escalate accordingly
+  - if "UpgradeTest", "hpa-upgrade", "ingress-upgrade" tests are failing in an upgrade/downgrade job, then indeed master/cluster is failing to upgrade or downgrade. Escalate to SIG-cluster-lifecycle
+  - if "UpgradeTest", "hpa-upgrade", "ingress-upgrade" tests are passing and other SIG specific tests that are failing, then upgrade/downgrade completed succesfully. Escalate individual failures to appropriate test owning SIG for triage and resolution
+  - To get a better and quicker feedback on upgrade/downgrade tests, we can look at upgrade jobs that have "parallel" in their title eg: [gce-1.10-master-upgrade-cluster-parallel](https://k8s-testgrid.appspot.com/sig-release-master-upgrade#gce-1.10-master-upgrade-cluster-parallel). These complete faster and are more stable since they don't run slow long running tests. If the parallel upgrade/downgrade jobs are green indicates we are mostly good with respect to upgrade functionality
+  - Yet another tip to assess seriousness of regression is to see if both gce and gke counterparts of a upgrade/downgrade jobs are failing eg: [gce-1.10-master-upgrade-master](https://k8s-testgrid.appspot.com/sig-release-master-upgrade#gce-1.10-master-upgrade-master) and [gke-gci-1.10-gci-master-upgrade-master](https://k8s-testgrid.appspot.com/sig-release-master-upgrade#gke-gci-1.10-gci-master-upgrade-master). If both are failing then its indicative of a systemic failure in upgrade functionlaity. If only gke jobs are failing then it might be a GKE only issue and does not block k8s release. In this case escalate to GKE Cluster Lifecycle team  (@roberthbailey, @krousey)
+
+## Tips and Tricks of the game
+
+### Checking test dashboards
 
 - Quirk: if a job is listed as FAILING but doesn't have "Overall" as one of its ongoing failures, it's not actually failing. It might be "red" from some previous test runs failures and will clear up after a few "green" runs
 - if a job is failing in one of the meta-stages (Up, Down, DumpClusterLogs, etc), find the owning SIG since it is a infra failure
-- if a job is failing because a specific test case is failing, and that test case has a [sig-foo] in its name, tag sig-foo in the issue and find appropriate owner within the sig
+- if a job is failing because a specific test case is failing, and that test case has a [sig-foo] in its name, tag SIG-foo in the issue and find appropriate owner within the SIG
 - with unit test case failures, try to infer the SIG from the path or OWNERS files in it. Otherwise find the owning SIG to help
 - with verify failures, try to infer the failure from the log. Otherwise find the owning SIG to help
 - if a test case is failing in one job consistently, but not others, both the job owner and test case owner are responsible for identifying why this combination is different
@@ -106,27 +171,26 @@ Examples:
 - [[e2e failure] [sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: udp](https://github.com/kubernetes/kubernetes/issues/54524)
 - [[e2e failure] [sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: http](https://github.com/kubernetes/kubernetes/issues/54571)
 
+### Monitoring Commits for test failure triangulation
+Yet another effective way for a signal lead to stay on top of code churn and regression is by monitoring commits to master and specific branch periodically.
+- Once a day look at https://github.com/kubernetes/kubernetes/commits/master/ for master or a specific branch
+- Look for any new end-to-end tests added by a PR
 
-### Reporting Status
+This helps us
+- Stay aware of tests’ history and identify ownership when they start failing
+- Identify possible culprit PRs incase of a regression
+- Usually if the volume of things merged is very low, then that’s a signal that something is terribly broken as well
 
-I'm not sure I want to act as a human dashboard generator on an ongoing basis, so I'd like to find a better way to do this.
+## Reporting Status
+Since 1.11 we started curating and broadcasting a weekly CI Signal report to the entire kubernetes developer community highlighting
+  - Top failing and flaky jobs and tests
+  - New failing and flaky jobs and tests in the past week
+  - Call out SIGs actively fixing and ignoring issues
+  - Call out potential release blocking issues
+  - Call out upcoming key dates e.g., Code slush, freeze etc
+  - [Link to the previous reports](https://docs.google.com/document/d/1y044OcaKGEUgj094JH1ZxnnLRHnqi0Kq0f4ov56kvxE/edit) 
+  - CC individual SIGs (kubernetes-sig-foo@googlegroups.com) that have failing tests also help in getting their attention
+  
+[Sample Weekly CI Signal Report](https://groups.google.com/forum/#!topic/kubernetes-dev/S9AuFMiIJkQ)
 
-I have been updating the sig-release issue for the latest release each time I scrub through dashboards, eg: [1.9.0-alpha.2 issue](https://github.com/kubernetes/sig-release/issues/22#issuecomment-340970138)
-
-## Code Slush
-
-I check [sig-release-master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking) and [sig-release-master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade) daily.
-
-I will ocasionally check [sig-release-1.y-blocking](https://k8s-testgrid.appspot.com/sig-release-1.y-blocking) and work with the Test Infra role to make sure the list of jobs looks correct
-
-## Code Freeze
-
-I check [sig-release-master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking) and [sig-release-master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade) daily.
-
-I expect more responsiveness from SIG's at this point. In addition to filing github issues, I start pinging issues for updates, and pinging sig slack channels.
-
-## Exit Code Freeze
-
-I stop looking at release-master-blocking
-
-I look solely at release-1.y-blocking and release-master-upgrade
+Such early and continuous reporting of test health proved greatly effective in rallying SIG attention to test failures and stabilizing the release much early in the release cycle. 

--- a/release-process-documentation/release-team-guides/ci-signal-playbook.md
+++ b/release-process-documentation/release-team-guides/ci-signal-playbook.md
@@ -3,32 +3,32 @@
 ## Overview of CI Signal responsibilities
 
 CI Signal lead assumes the responsibility of the quality gate for the release. This person is responsible for:
-- Monitors various e2e tests in sig-release dashboard ([master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking), [master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade), [x.y-blocking](https://k8s-testgrid.appspot.com/sig-release-1.11-blocking))on a regular basis and provides early and continuous signals on release and test health to both the Release team and SIGs
-- Ensures that all release blocking tests provide a clear Go/No-Go signal for the release
-- Flags regression as close to source as possible i.e., as soon as the offending code was merged
-- Files and triages issues proactively for test failures and flakes, finds appropriate SIG/owner, follows up on status and verifies fixes on newer test runs
-- Studies patterns/history of test health from previous releases and works closely with SIGs and test owners to 
+- Monitoring various e2e tests in sig-release dashboards ([master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking), [master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade), [x.y-blocking](https://k8s-testgrid.appspot.com/sig-release-1.11-blocking)) on a regular basis and providing early and continuous signals on release and test health to both Release team and SIGs
+- Ensuring that all release blocking tests provide a clear Go/No-Go signal for the release
+- Flagding regression as close to source as possible i.e., as soon as the offending code was merged
+- Filing issues proactively for test failures and flakes, triaging issues to appropriate SIG/owner, following up on status and verifying fixes on newer test runs
+- Studying patterns/history of test health from previous releases and working closely with SIGs and test owners to 
   - Understand and fix the test for the current release
   - Understand if the test needs to be release blocking
   - Advise Release team in making informed go/no-go calls 
   - Work with SIG-Testing on any possible test infra improvement to help improve test pass rate
-- Makes recommendations to SIG-Release for promoting and demoting Release blocking and Merge blocking tests as per the [Blocking tests Proposal](https://docs.google.com/document/d/1kCDdmlpTnHPQt5z8JzODdFCc3T2D4MKR53twsDZu20c/edit)
+- Making recommendations to SIG-Release for promoting and demoting release blocking and merge blocking tests as per the [Blocking tests Proposal](https://docs.google.com/document/d/1kCDdmlpTnHPQt5z8JzODdFCc3T2D4MKR53twsDZu20c/edit)
 
 ### Explicit detail is important:
 
-- If you're looking for answer that's not in this document, don't just ask me, please file an issue so we can keep the document current.
-- If I don't file an issue for a failing job or test, _I will lose track of it_, so I err on the side of filing an issue even if someone told me something in some other medium
-- If a dashboard isn't listed here, or a test isn't on one of the listed dashboards, **_I'm not looking at it_**
+- If you're looking for answer that's not in this document, please file an issue so we can keep the document current.
+- Generally CI Signal lead errs on the side of filing an issue for each test failure or flake before following up with SIGs/owners. This way we dont _lose track of an issue_
+- If a dashboard isn't listed here, or a test isn't on one of the listed dashboards, **_CI Signal lead is not looking at it_**
 
 ## Requirements
 
-- I need the ability to notify kubernetes org github teams, so I must be a kubernetes org collaborator or member
+- Signal lead needs the ability to notify kubernetes org github teams, so must be a kubernetes org collaborator or member
   - The process to become one of these is in [our community membership ladder](https://github.com/kubernetes/community/blob/master/community-membership.md#requirements-for-outside-collaborators)
-- I need the ability to add a milestone to issues, so I must be a member of the [kubernetes-pm github team](https://github.com/orgs/kubernetes/teams/kubernetes-pm/members)
+- Signal lead needs the ability to add a milestone to issues, so must be a member of the [kubernetes-pm github team](https://github.com/orgs/kubernetes/teams/kubernetes-pm/members)
   - The process to join this group is in [our community project-managers page](https://github.com/kubernetes/community/blob/master/project-managers/README.md#joining-the-group)
-- I need to understand what tests matter and generally how our testing infra is wired together
-  - I can ask previous CI Signal leads for advice
-  - I can ask SIG-Testing for guidance
+- Signal lead need to understand what tests matter and generally how our testing infra is wired together
+  - He/she can ask previous CI Signal leads for advice
+  - He/she can ask SIG-Testing for guidance
 
 ## Overview of tasks across release timeline
 
@@ -36,7 +36,7 @@ For any release, its schedule and activities/deliverable for each week will be p
 
 ### Pre Feature Freeze
 
-Here are some good early deliverables from the CI Signal lead between start of release and feature freeze.
+Here are some good early deliverables from the CI Signal lead between start of the release to feature freeze.
 - Maintain a master tracking sheet and keep it up-to-date with issues tracking any test failure/flake - [Sample sheet](https://docs.google.com/spreadsheets/d/1j2K8cxraSp8jZR2S-kJUT6GNjtXYU9hocNRiVUGZWvc/edit#gid=127492362)
 - Copy over any open test issues from previous release (ask previous CI Signal lead for the tracker sheet) and follow up on them with owners
 - Monitor [master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking) and [master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade) dashboards **twice a week** and ensure all failures and flakes are tracked via open issues
@@ -44,78 +44,80 @@ Here are some good early deliverables from the CI Signal lead between start of r
   - Make sure the issue is assigned against the current milestone 1.x, using /milestone
   - Assign the issue to appropriate SIG using /sig label
   - CC the release manager and bug triage lead
-  - Add @kubernetes/sig-foo-test-failures to draw SIG’s attention to the issue
+  - Add @kubernetes/sig-foo-test-failures to draw SIG-foo’s attention to the issue
   - Post the test failure in SIG’s Slack channel to get help in routing the issue to the rightful owner(s)
   - [Sample test failure issue](https://github.com/kubernetes/kubernetes/issues/63611)
-- Build and maintain a document of area experts / owners across SIGs for future needs eg: Scalability experts, upgrade test experts etc
+- Build and maintain a document of area experts / owners across SIGs for future needs e.g.: Scalability experts, upgrade test experts etc
   
 #### **_Best Practice:_** 
-The SLA and involvement of signal lead at this stage might vary from release to release (and the CI Signal lead). However in an effort to establish a baseline of the test health, the signal lead can take an initial stab at the tests runs at the start of the release, open issues, gather and report on the current status. Post that, it might suffice to check on the tests **twice a week** due to high code churn and expected test instability.
+The SLA and involvement of signal lead at this stage might vary from release to release (and the CI Signal lead). However in an effort to establish an early baseline of the test health the signal lead can take an initial stab at the tests runs at the start of the release, open issues, gather and report on the current status. Post that, it might suffice to check on the tests **twice a week** due to high code churn and expected test instability.
 
 ### Feature Freeze to Code Slush
 
-Day to day tasks remain pretty much remain the same as before, with the following slight changes
+Day to day tasks remain pretty much the same as before, with the following slight changes
 - Monitor [master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking) dashboard **daily**
 - Monitor [master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade) **every other day**
-- Starting now, curate a **weekly CI Signal report** escalating current test failures and flakes and send to kubernetes-dev@googlegroups.com community. [See below](#reporting-status) for more details
+- Starting now, curate a **weekly CI Signal report** escalating current test failures and flakes and send to kubernetes-dev@googlegroups.com community. [See below](#reporting-status) for more details on the report format and contents
 
 ### Code Slush to Code Freeze
 
 This is when things really begin to ramp up in the release cycle with active bug triaging and followup on possible release blocking issues to assess release health. Day to day tasks of CI Signal lead include
-- Audit test status of master-blocking, master-upgrade and release-1.x.y-blocking dashboards on **daily basis**
-- Keep issues' status upto-date on GitHub
-- Work closely with SIGs, test owners, Bug Triage lead and Release team in triaging, punting and closing issues
-- Update issue tracker frequently so anyone on the release team can get latest status and help followup on open issues
-- Continue sending [weekly CI signal report](#reporting-status)
+- Auditing test status of master-blocking, master-upgrade and release-1.x.y-blocking dashboards on **daily basis**
+- Keeping issues' status upto-date on GitHub
+- Working closely with SIGs, test owners, bug triage lead and Release team in triaging, punting and closing issues
+- Updating issue tracker frequently so anyone on the release team can get to speed and help followup on open issues
+- Continuing to send [weekly CI signal report](#reporting-status)
 
 ### During Code Freeze
 
 - Continue best practices from Code slush stage. Monitor master-blocking, master-upgrade and release-1.x.y-blocking dashboards on **daily basis**
 - Quickly escalate any new failures to release team and SIGs
+- Continuing to send [weekly CI signal report](#reporting-status)
 
 ### Exit Code Freeze
 
 - Once 1.x.y-rc.1 release branch is cut and master re-opens for next release PRs, stop monitoring master-blocking and **focus only on master-upgrade and 1.x.y-blocking dashboards on daily basis**
+- If tests have stabilized (they should have by now), stop sending weekly CI report
 
 ## Special high risk test categories to monitor
 
-Historically there a couple of families of test that are hard to stabilize, regression prone and pose a high risk of delaying and/or derailing a release. As CI Sigbal lead it is highly recommended to pay close attention and extra caution when dealing with test failures in the following areas.
+Historically there are a couple of families of test that are hard to stabilize, regression prone and pose a high risk of delaying and/or derailing a release. As CI Signal lead it is highly recommended to pay close attention and extra caution when dealing with test failures in the following areas.
 
 ### Scalability tests
 Scalability testing is inherently challenging and regressions in this area are potentially a huge project risk 
 - Requires lots and lots of servers running tests, and hence expensive
 - Tests are long running, so especially hard/expensive/slow to resolve issues via Git bisection
-- Examination of results is actually the bigger more expensive part of the situation.  
+- Examination of results is actually the bigger more expensive part of the situation
 
 The following scalability jobs/tests could regress quite easily (due to seemingly unrelated PRs anywhere in k8s codebase), require constant manual monitoring/triaging and domain expertise to investigate and resolve.
 - [master-blocking gci-gce-100](https://k8s-testgrid.appspot.com/sig-release-master-blocking#gci-gce-100)
 - [master-blocking gce-scale-correctness](https://k8s-testgrid.appspot.com/sig-release-master-blocking#gce-scale-correctness)
 - [master-blocking gce-scale-performance](https://k8s-testgrid.appspot.com/sig-release-master-blocking#gce-scale-performance)
-- [release 1.xx-blocking gce-scalability-1.xx](https://k8s-testgrid.appspot.com/sig-release-1.10-blocking#gce-scalability-1.10) (Post release branch cut)
+- [release 1.xx-blocking gce-scalability-1.xx](https://k8s-testgrid.appspot.com/sig-release-1.10-blocking#gci-gce-scalability-1.10) (Post release branch cut)
 
 The CI Signal lead should 
 - Continuously monitor these tests early in the release cycle, ensure issues are filed and escalated to the Release team and right owners in SIG-Scalability (@bobwise, @shyamjvs, @wojtek-t) 
-- Work with SIG-Scalability to understand if the failure is a product regression versus a test issue (flake) and in either cases followup closely on a fix
-- Additionally it might help to monitor SIG-Scalability’s performance dashboard to flag if and when there is considerable performance degradation
+- Work with SIG-Scalability to understand if the failure is a product regression versus a test issue (flake) and in either case followup closely on a fix
+- Additionally, it might help to monitor SIG-Scalability’s performance dashboard to flag if and when there is considerable performance degradation
 
-Starting in 1.11, scalability tests are now blocking OSS presubmit. Specifically we are running performance tests on gce-100 and kubemark-500 setups. This is a step towards catching regressions sooner and stabilizing the release faster.
+Starting in 1.11, scalability tests are now blocking OSS presubmits. Specifically we are running performance tests on gce-100 and kubemark-500 setups. This is a step towards catching regressions sooner and stabilizing the release faster.
 
 ### Upgrade/Downgrade tests
-[Upgrade tests](https://k8s-testgrid.appspot.com/sig-release-master-upgrade#Summary) are inherently tricky in the way they are setup to run and test. We run multiple  combinations that test upgrading an downgrading 
+[Upgrade tests](https://k8s-testgrid.appspot.com/sig-release-master-upgrade#Summary) are inherently tricky in the way they are setup to run and test. We run multiple  combinations that test upgrading and downgrading of
 - just the master
 - entire cluster
 - on gce and gke
 - in parallel and otherwise
 
-We also run **skewed tests** which involve running the old k8s version’s tests i.e., 1.x-1.y tests, against the new (upcoming) version i.e., 1.x.y. Many of those tests will (and did) fail because of intentional changes in the new version, putting us in the position of back-patching tests to old versions and thus forcing us to add lots of new code to a stable release. 
+We also run **skewed tests** which involve running the old k8s version’s tests i.e., 1.x-1.y tests, against the new (upcoming) version i.e., 1.x.y. Many of those tests will fail because of intentional changes in the new version, putting us in the position of back-patching tests to old versions and thus forcing us to add lots of new code to a stable release. 
 
 The CI Signal lead should 
 - Continuously monitor the [master-upgrade tests](https://k8s-testgrid.appspot.com/sig-release-master-upgrade#Summary) throughout the cycle
 - If an upgrade/downgrade job is listed as FAILING, check the following and escalate accordingly
-  - if "UpgradeTest", "hpa-upgrade", "ingress-upgrade" tests are failing in an upgrade/downgrade job, then indeed master/cluster is failing to upgrade or downgrade. Escalate to SIG-cluster-lifecycle
-  - if "UpgradeTest", "hpa-upgrade", "ingress-upgrade" tests are passing and other SIG specific tests that are failing, then upgrade/downgrade completed succesfully. Escalate individual failures to appropriate test owning SIG for triage and resolution
-  - To get a better and quicker feedback on upgrade/downgrade tests, we can look at upgrade jobs that have "parallel" in their title eg: [gce-1.10-master-upgrade-cluster-parallel](https://k8s-testgrid.appspot.com/sig-release-master-upgrade#gce-1.10-master-upgrade-cluster-parallel). These complete faster and are more stable since they don't run slow long running tests. If the parallel upgrade/downgrade jobs are green indicates we are mostly good with respect to upgrade functionality
-  - Yet another tip to assess seriousness of regression is to see if both gce and gke counterparts of a upgrade/downgrade jobs are failing eg: [gce-1.10-master-upgrade-master](https://k8s-testgrid.appspot.com/sig-release-master-upgrade#gce-1.10-master-upgrade-master) and [gke-gci-1.10-gci-master-upgrade-master](https://k8s-testgrid.appspot.com/sig-release-master-upgrade#gke-gci-1.10-gci-master-upgrade-master). If both are failing then its indicative of a systemic failure in upgrade functionlaity. If only gke jobs are failing then it might be a GKE only issue and does not block k8s release. In this case escalate to GKE Cluster Lifecycle team  (@roberthbailey, @krousey)
+  - if "UpgradeTest", "hpa-upgrade", "ingress-upgrade" tests are failing in an upgrade/downgrade job, then indeed master/cluster is failing to upgrade or downgrade. This is potentially release blocking. Escalate to SIG-cluster-lifecycle 
+  - if "UpgradeTest", "hpa-upgrade", "ingress-upgrade" tests are passing and other SIG specific tests are failing, then upgrade/downgrade completed succesfully. Such failures are historically mostly flakes, resolve in subsequent runs and hence mostly not release blocking. Nevertheless, file issues (even for flakes) and escalate to appropriate test owning SIG for triage, assessment and resolution
+  - To get a better and quicker feedback on upgrade/downgrade tests, we can look at upgrade jobs that have "parallel" in their title eg: [gce-1.10-master-upgrade-cluster-parallel](https://k8s-testgrid.appspot.com/sig-release-master-upgrade#gce-1.10-master-upgrade-cluster-parallel). These complete faster and are more stable since they don't run slow long running tests. If the parallel upgrade/downgrade jobs are green, this indicates we are mostly good with respect to upgrade functionality
+  - Yet another tip to assess seriousness of the failure is to see if both gce and gke counterparts of a upgrade/downgrade job are failing eg: [gce-1.10-master-upgrade-master](https://k8s-testgrid.appspot.com/sig-release-master-upgrade#gce-1.10-master-upgrade-master) and [gke-gci-1.10-gci-master-upgrade-master](https://k8s-testgrid.appspot.com/sig-release-master-upgrade#gke-gci-1.10-gci-master-upgrade-master). If both are failing then its indicative of a systemic failure in upgrade functionality. If only gke jobs are failing then it might be a GKE only issue and does not block k8s release. In this case escalate to GKE Cluster Lifecycle team  (@roberthbailey, @krousey)
 
 ## Tips and Tricks of the game
 
@@ -189,8 +191,8 @@ Since 1.11 we started curating and broadcasting a weekly CI Signal report to the
   - Call out potential release blocking issues
   - Call out upcoming key dates e.g., Code slush, freeze etc
   - [Link to the previous reports](https://docs.google.com/document/d/1y044OcaKGEUgj094JH1ZxnnLRHnqi0Kq0f4ov56kvxE/edit) 
-  - CC individual SIGs (kubernetes-sig-foo@googlegroups.com) that have failing tests also help in getting their attention
+  - CCing individual SIGs (kubernetes-sig-foo@googlegroups.com) that own failing tests help in getting their attention
   
 [Sample Weekly CI Signal Report](https://groups.google.com/forum/#!topic/kubernetes-dev/S9AuFMiIJkQ)
 
-Such early and continuous reporting of test health proved greatly effective in rallying SIG attention to test failures and stabilizing the release much early in the release cycle. 
+Early and continuous reporting of test health proved greatly effective in rallying SIG attention to test failures and stabilizing the release much early in the release cycle. 

--- a/release-process-documentation/release-team-guides/ci-signal-playbook.md
+++ b/release-process-documentation/release-team-guides/ci-signal-playbook.md
@@ -1,6 +1,19 @@
 # CI Signal Lead Playbook
 
-Explicit detail is important:
+## Overview of CI Signal responsibilities
+CI Signal lead assumes the responsibility of the quality gate for the release. This person is responsible for:
+- Monitors various e2e tests in sig-release dashboard ([master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking), [master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade), [x.y-blocking](https://k8s-testgrid.appspot.com/sig-release-1.11-blocking))on a regular basis and provides early and continuous signals on release and test health to both the Release team and SIGs
+- Ensures that all release blocking tests provide a clear Go/No-Go signal for the release
+- Flags regression as close to source as possible i.e., as soon as the offending code was merged
+- Files and triages issues proactively for test failures and flakes, finds appropriate SIG/owner, follows up on status and verifies fixes on newer test runs
+- Studies patterns/history of test health from previous releases and works closely with SIGs and test owners to 
+  - Understand and fix the test for the current release
+  - Understand if the test needs to be release blocking
+  - Advise Release team in making informed go/no-go calls 
+  - Work with sig-testing on any possible test infra improvement to help improve test pass rate
+- Makesrecommendations to Sig-Release for promoting and demoting Release blocking and Merge blocking tests as per the [Blocking tests Proposal](https://docs.google.com/document/d/1kCDdmlpTnHPQt5z8JzODdFCc3T2D4MKR53twsDZu20c/edit)
+
+### Explicit detail is important:
 - If you're looking for answer that's not in this document, don't just ask me, please file an issue so we can keep the document current.
 - If I don't file an issue for a failing job or test, _I will lose track of it_, so I err on the side of filing an issue even if someone told me something in some other medium
 - If a dashboard isn't listed here, or a test isn't on one of the listed dashboards, **_I'm not looking at it_**

--- a/release-process-documentation/release-team-guides/ci-signal-playbook.md
+++ b/release-process-documentation/release-team-guides/ci-signal-playbook.md
@@ -11,7 +11,7 @@ CI Signal lead assumes the responsibility of the quality gate for the release. T
   - Understand if the test needs to be release blocking
   - Advise Release team in making informed go/no-go calls 
   - Work with sig-testing on any possible test infra improvement to help improve test pass rate
-- Makesrecommendations to Sig-Release for promoting and demoting Release blocking and Merge blocking tests as per the [Blocking tests Proposal](https://docs.google.com/document/d/1kCDdmlpTnHPQt5z8JzODdFCc3T2D4MKR53twsDZu20c/edit)
+- Makes recommendations to Sig-Release for promoting and demoting Release blocking and Merge blocking tests as per the [Blocking tests Proposal](https://docs.google.com/document/d/1kCDdmlpTnHPQt5z8JzODdFCc3T2D4MKR53twsDZu20c/edit)
 
 ### Explicit detail is important:
 - If you're looking for answer that's not in this document, don't just ask me, please file an issue so we can keep the document current.
@@ -27,28 +27,47 @@ CI Signal lead assumes the responsibility of the quality gate for the release. T
   - I can ask previous CI Signal leads for advice
   - I can ask sig-testing for guidance
 
-## Status Quo
+## Overview of tasks across release timeline
 
-Currently, here's what I'm doing as the CI Signal role for release 1.y:
+For any release, its schedule and activities/deliverable for each week will be published in the release directory, e.g: [1.11 schedule](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.11/release-1.11.md#timeline). This section talks about specific CI Signal lead deliverable for each milestone in the release cycle.
 
-### Checking test dashboards
+### Pre Feature Freeze
+Here are some good early deliverables from the CI Signal lead between start of release and feature freeze
+- Maintain a master tracking sheet and keep it up-to-date with  issues tracking any test issue (failure/flake) - [Sample sheet](https://docs.google.com/spreadsheets/d/1j2K8cxraSp8jZR2S-kJUT6GNjtXYU9hocNRiVUGZWvc/edit#gid=127492362)
+- Copy over any open test issues from previous release (ask previous CI Signal lead for the tracker sheet) and follow up on them with owners
+- Monitor [master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking) and [master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade) dashboards **twice a week** and ensure all failures and flakes have issues open
+  - Make sure all open issues have a kind/bug, priority/flake or priority/failing-test, priority/important-soon labels 
+  - Make sure the issue is assigned against the current milestone 1.xx, using /milestone
+  - Assign the issue to appropriate SIG using /sig label
+  - Add @kubernetes/sig-foo-test-failures to get SIG’s attention on the issue
+  - CC the release manager and bug triage lead
+  - Draw SIG's attention to the test failure by post in SIG’s Slack channel. This can also help routing the issue to the rightful owner(s) in the SIG
+  - [Sample test failure issue](https://github.com/kubernetes/kubernetes/issues/63611)
+- Build and maintain a document of area experts / owners across SIGs for future needs eg: Scalability experts, upgrade test experts etc
+  
+#### **_Best Practice:_** 
+The SLA and involvement of signal lead at this stage might vary from release to release (and the CI Signal lead). However in an effort to establish a baseline of the test health, the signal lead can take an initial stab at the tests runs at the start of the release, open issues, gather and report on the current status. Post that, it might suffice to check on the tests **twice a week** due to high code churn and expected test instability.
 
-I check [sig-release-master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking) daily.
+### Feature Freeze to Code Freeze
+Day to day tasks remain pretty much the same as before, with the following slight changes
+- Post 1.xx.0-beta.0 release, [master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking) and [master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade) dashboards **every other day**.
+- Starting now, curate and send a **Weekly CI Signal report** escalating current test failures and flakes to the entire kubernetes-dev community. Such conitnuous and early reporting of test health went a long way in rallying SIG attention to test failures and stabilizing the release much early in the release cycle.
+  - 
 
-- quirk: if a job is listed as FAILING but doesn't have "Overall" as one of its ongoing failures, it's not actually failing
-- if a job is failing in one of the meta-stages (Up, Down, DumpClusterLogs, etc), I find the owning sig
-- if a job is failing because a specific test case is failing, and that test case has a [sig-foo] in its name, I go bug sig-foo
-- with unit test case failures, I try to infer the sig from the path, or OWNERS files in it, otherwise I find the owning sig to help
-- with verify failures, I try to infer the failure from the log, otherwise I find the owning sig to help
+### Tips and Tricks when checking test dashboards
+
+- Quirk: if a job is listed as FAILING but doesn't have "Overall" as one of its ongoing failures, it's not actually failing. It might be "red" from some previous test runs failures and will clear up after a few "green" runs
+- if a job is failing in one of the meta-stages (Up, Down, DumpClusterLogs, etc), find the owning SIG since it is a infra failure
+- if a job is failing because a specific test case is failing, and that test case has a [sig-foo] in its name, tag sig-foo in the issue and find appropriate owner within the sig
+- with unit test case failures, try to infer the SIG from the path or OWNERS files in it. Otherwise find the owning SIG to help
+- with verify failures, try to infer the failure from the log. Otherwise find the owning SIG to help
 - if a test case is failing in one job consistently, but not others, both the job owner and test case owner are responsible for identifying why this combination is different
 
-I will ocasionally check [sig-release-master-upgrade](https://k8s-testgrid.appspot.com/sig-release-master-upgrade)
+### Routing test issues to SIG/owner
 
-### Pinging SIG's
+This can be done in 2 ways (i) including @kubernetes/sig-foo-test-failures teams in the issue files and (ii) going to the #sig-foo slack channel if you need help routing the failue to appropriate owner.
 
-I do this by using @kubernetes/sig-foo-test-failures teams when I file issues, or going to the #sig-foo slack channel if I need routing help and know someone's around
-
-If a job as a whole is failing, I file a v1.y issue in kubernetes/kubernetes titled:`[job failure] job name issue`
+If a job as a whole is failing, file a v1.y issue in kubernetes/kubernetes titled:`[job failure] job name issue`
 ```
 /priority critical-urgent
 /priority failing-test
@@ -64,7 +83,7 @@ https://k8s-testgrid.appspot.com/sig-sig-release-master-blocking#[THE FAILING JO
 Examples:
 - [[job failure] ci-kubernetes-e2e-kubeadm-gce](https://github.com/kubernetes/kubernetes/issues/54905)
 
-If a test case is failing, I file a v1.y milestone issue in kubernetes/kubernetes titled: `[e2e failure] full test case name`
+If a test case is failing, file a v1.y milestone issue in kubernetes/kubernetes titled: `[e2e failure] full test case name`
 ```
 /priority critical-urgent
 /priority failing-test


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/sig-release/issues/189#issuecomment-398533947

Update README.md and ci-signal-palybook.md post various CI Signal process improvements in 1.11. I specifically talk about
1. Various CI Signal lead tasks / deliverables across the various stages in the release cycle
2. Weekly CI signal report format and details for broadcasting test and release health 